### PR TITLE
Fix a typo

### DIFF
--- a/04-01 - Your First Project/C#/My First Project/My First Project/Program.cs
+++ b/04-01 - Your First Project/C#/My First Project/My First Project/Program.cs
@@ -49,7 +49,7 @@ namespace My_First_Project
             }
 
             // Getting the save variable
-            Console.WriteLine($"Give me a helo-related verb (present tense):");
+            Console.WriteLine($"Give me a hero-related verb (present tense):");
             save = Console.ReadLine();
 
             // Getting the unplugged variable

--- a/04-01 - Your First Project/py/My First Project.py
+++ b/04-01 - Your First Project/py/My First Project.py
@@ -38,7 +38,7 @@ for i in range(len(profession)):
     profession[i] = input(f"Profession (plural) {i+1} / {len(profession)}: ")
 
 # Getting the save variable
-save = input(f"Give me a helo-related verb (present tense): ")
+save = input(f"Give me a hero-related verb (present tense): ")
 
 # Getting the unplugged variable
 unplugged = input(f"Now give me a verb that makes you think about relief (past tense): ")


### PR DESCRIPTION
As seen in issue #1, there's a typo in both the Python and C# versions of the program. Where it should say "hero-related verb", it instead says "**helo**-related verb".